### PR TITLE
Added new hotkeys for the RRT Interface

### DIFF
--- a/src/rrt-viewer/MainWindow.cpp
+++ b/src/rrt-viewer/MainWindow.cpp
@@ -107,6 +107,11 @@ MainWindow::MainWindow() {
     new QShortcut(QKeySequence(Qt::Key_R), _rrtWidget, SLOT(slot_run()));
     new QShortcut(QKeySequence(Qt::Key_S), _rrtWidget, SLOT(slot_stop()));
     new QShortcut(QKeySequence(Qt::Key_C), _rrtWidget, SLOT(slot_reset()));
+    new QShortcut(QKeySequence(Qt::Key_O), _rrtWidget, SLOT(slot_clearObstacles()));
+    new QShortcut(QKeySequence(Qt::Key_T), _rrtWidget, SLOT(slot_step()));
+    new QShortcut(QKeySequence(Qt::Key_B), _rrtWidget, SLOT(slot_stepBig()));
+
+
 }
 
 void MainWindow::slot_updateGoalBiasLabel(int value) {


### PR DESCRIPTION
Fixed the "Assign hotkeys for all the controls in the rrt interface" issue.
O to Clear Obstacles.
T for Step
B for Big Step

(edit by jgkamat) closes #28