### PR TITLE
Fix build on debian 9 and other systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 3.2.0)
 project(rrt)
 
-# c++11
 # note: the -fPIC flag is for building with Qt...
 #       it complains about position-independent code otherwise
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -fPIC")
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # setup ccache to speed up recompiles.  It's especially useful when switching back and forth
 # between branches where you'd normally have to recompile things many times.
@@ -59,6 +60,8 @@ set(lib_SRC
 # add_library("RRT" STATIC ${lib_SRC})
 add_library("RRT" ${lib_SRC})
 add_dependencies(RRT Flann)
+# Fix 'LZ4 not found' issue on some systems
+target_link_libraries(RRT ${FLANN_LIBRARIES})
 
 
 # copy headers to install directory


### PR DESCRIPTION
Fixes RRT build on debian 9

For reference, the error we were getting was:

```
x86_64-linux-gnu/libQt5Network.so.5.7.1 /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5.7.1 /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.7.1 && :
CMakeFiles/rrt-viewer.dir/src/rrt-viewer/RRTWidget.cpp.o: In function `flann::serialization::SaveArchive::initBlock()':
/usr/include/flann/util/serialization.h:406: undefined reference to `LZ4_resetStreamHC'
CMakeFiles/rrt-viewer.dir/src/rrt-viewer/RRTWidget.cpp.o: In function `flann::serialization::SaveArchive::flushBlock()':
/usr/include/flann/util/serialization.h:425: undefined reference to `LZ4_compress_HC_continue'
/usr/include/flann/util/serialization.h:443: undefined reference to `LZ4_compress_HC_continue'
CMakeFiles/rrt-viewer.dir/src/rrt-viewer/RRTWidget.cpp.o: In function `flann::serialization::LoadArchive::decompressAndLoadV10(_IO_FILE*)':
/usr/include/flann/util/serialization.h:610: undefined reference to `LZ4_decompress_safe'
CMakeFiles/rrt-viewer.dir/src/rrt-viewer/RRTWidget.cpp.o: In function `flann::serialization::LoadArchive::initBlock(_IO_FILE*)':
/usr/include/flann/util/serialization.h:667: undefined reference to `LZ4_setStreamDecode'
CMakeFiles/rrt-viewer.dir/src/rrt-viewer/RRTWidget.cpp.o: In function `flann::serialization::LoadArchive::loadBlock(char*, unsigned long, _IO_FILE*)':
/usr/include/flann/util/serialization.h:690: undefined reference to `LZ4_decompress_safe_continue'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
makefile:2: recipe for target 'all' failed
```

Which seems to be pretty common when people are linking flann, something must be wrong with the stock FindFlann.

If this passes CI, merging.