### PR TITLE
Change to Q prefixed signal/slots keywords to fix compilation issue.

### DIFF
--- a/src/rrt-viewer/RRTWidget.cpp
+++ b/src/rrt-viewer/RRTWidget.cpp
@@ -56,7 +56,7 @@ void RRTWidget::reset() {
 
     _biRRT->setWaypoints(waypoints);
 
-    emit signal_stepped();
+    Q_EMIT signal_stepped();
 
     update();
 }
@@ -115,7 +115,7 @@ void RRTWidget::_step(int numTimes) {
         RRT::SmoothPath<Vector2f>(_previousSolution, *_stateSpace);
     }
 
-    emit signal_stepped();
+    Q_EMIT signal_stepped();
 
     update();
 }

--- a/src/rrt-viewer/RRTWidget.hpp
+++ b/src/rrt-viewer/RRTWidget.hpp
@@ -41,7 +41,7 @@ public:
     void setASCEnabled(bool enabled);
     float ascEnabled() const { return _biRRT->isASCEnabled(); }
 
-public slots:
+public Q_SLOTS:
     void run();
     void stop();
     void reset();
@@ -52,7 +52,7 @@ public slots:
     // called on a timer interval by run()
     void _run_step();
 
-signals:
+Q_SIGNALS:
     void signal_stepped();
 
 protected:


### PR DESCRIPTION
This is needed on master to fix compiling the RRT :smile:.

Seems good to me :D 

Fixes:

```
[74/144] Automatic moc for target rrt-viewer
FAILED: external/rrt/CMakeFiles/rrt-viewer_automoc 
cd /home/jay/Code/robocup-software/build/external/rrt && /usr/bin/cmake -E cmake_autogen /home/jay/Code/robocup-software/build/external/rrt/CMakeFiles/rrt-viewer_automoc.dir/ Debug
Generating moc source rrt-viewer_automoc.dir/moc_RRTWidget_3H5TXSEQW6NGX2.cpp
/home/jay/Code/robocup-software/external/rrt/src/rrt-viewer/RRTWidget.hpp:100: Error: NOTIFY signal 'signal_stepped' of property 'iterations' does not exist in class RRTWidget.
AUTOGEN: error: process for /home/jay/Code/robocup-software/build/external/rrt/rrt-viewer_automoc.dir/moc_RRTWidget_3H5TXSEQW6NGX2.cpp failed:
/home/jay/Code/robocup-software/external/rrt/src/rrt-viewer/RRTWidget.hpp:100: Error: NOTIFY signal 'signal_stepped' of property 'iterations' does not exist in class RRTWidget.

```