### PR TITLE
Reversed transition-checking on the reverse tree

### DIFF
--- a/src/rrt/BiRRT.hpp
+++ b/src/rrt/BiRRT.hpp
@@ -17,8 +17,8 @@ public:
           std::function<size_t(T)> hash, int dimensions,
           std::function<T(double*)> arrayToT = NULL,
           std::function<void(T, double*)> TToArray = NULL)
-        : _startTree(stateSpace, hash, dimensions, arrayToT, TToArray),
-          _goalTree(stateSpace, hash, dimensions, arrayToT, TToArray) {
+        : _startTree(stateSpace, hash, dimensions, true, arrayToT, TToArray),
+          _goalTree(stateSpace, hash, dimensions, false, arrayToT, TToArray) {
         _minIterations = 0;
         reset();
     }
@@ -132,8 +132,8 @@ public:
         if (newGoalNode) {
             otherNode = _findBestPath(newGoalNode->state(), _startTree, &depth);
             if (otherNode && depth + newGoalNode->depth() < _solutionLength &&
-                _goalTree.stateSpace().transitionValid(newGoalNode->state(),
-                                                       otherNode->state())) {
+                _goalTree.stateSpace().transitionValid(otherNode->state(),
+                                                       newGoalNode->state())) {
                 _startSolutionNode = otherNode;
                 _goalSolutionNode = newGoalNode;
                 _solutionLength = newGoalNode->depth() + depth;

--- a/src/rrt/BiRRT.hpp
+++ b/src/rrt/BiRRT.hpp
@@ -202,7 +202,7 @@ private:
     int _minIterations;
 
     int _solutionLength;
-    const Node<T>*_startSolutionNode, *_goalSolutionNode;
+    const Node<T> *_startSolutionNode, *_goalSolutionNode;
 };
 
 }  // namespace RRT

--- a/src/rrt/BiRRT.hpp
+++ b/src/rrt/BiRRT.hpp
@@ -202,7 +202,7 @@ private:
     int _minIterations;
 
     int _solutionLength;
-    const Node<T>* _startSolutionNode, *_goalSolutionNode;
+    const Node<T>*_startSolutionNode, *_goalSolutionNode;
 };
 
 }  // namespace RRT

--- a/src/rrt/BiRRTTest.cpp
+++ b/src/rrt/BiRRTTest.cpp
@@ -54,4 +54,20 @@ TEST(BiRRT, multipleRuns) {
     }
 }
 
+TEST(BiRRT, intoObstacle) {
+    // The BiRRT should fail if the goal is in an obstacle.
+    Vector2d start = {1, 1}, goal = {30, 30};
+
+    auto state_space = make_shared<GridStateSpace>(50, 50, 50, 50);
+    state_space->obstacleGrid().obstacleAt(30, 30) = true;
+
+    BiRRT<Vector2d> biRRT(state_space, hash, dimensions);
+    biRRT.setStartState(start);
+    biRRT.setGoalState(goal);
+    biRRT.setStepSize(1);
+    biRRT.setMaxIterations(1000);
+
+    ASSERT_FALSE(biRRT.run());
+}
+
 }  // namespace RRT

--- a/src/rrt/Tree.hpp
+++ b/src/rrt/Tree.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
-#include <deque>
 #include <flann/algorithms/dist.h>
 #include <flann/algorithms/kdtree_single_index.h>
+#include <stdlib.h>
+#include <deque>
 #include <flann/flann.hpp>
 #include <functional>
 #include <list>
 #include <memory>
 #include <rrt/StateSpace.hpp>
 #include <stdexcept>
-#include <stdlib.h>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
@@ -128,8 +128,7 @@ public:
     Tree(const Tree&) = delete;
     Tree& operator=(const Tree&) = delete;
     Tree(std::shared_ptr<StateSpace<T>> stateSpace,
-         std::function<size_t(T)> hashT, int dimensions,
-         bool forward = true,
+         std::function<size_t(T)> hashT, int dimensions, bool forward = true,
          std::function<T(double*)> arrayToT = NULL,
          std::function<void(T, double*)> TToArray = NULL)
         : _kdtree(flann::KDTreeSingleIndexParams()),
@@ -237,9 +236,8 @@ public:
         for (int i = 0; i < _maxIterations; i++) {
             Node<T>* newNode = grow();
 
-            if (newNode &&
-                _stateSpace->distance(newNode->state(), _goalState) <
-                    _goalMaxDist)
+            if (newNode && _stateSpace->distance(newNode->state(), _goalState) <
+                               _goalMaxDist)
                 return true;
         }
 
@@ -365,7 +363,9 @@ public:
 
         //  Make sure there's actually a direct path from @source to
         //  @intermediateState.  If not, abort
-        if (!_stateSpace->transitionValid(_forward ? source->state() : intermediateState, _forward ? intermediateState : source->state())) {
+        if (!_stateSpace->transitionValid(
+                _forward ? source->state() : intermediateState,
+                _forward ? intermediateState : source->state())) {
             return nullptr;
         }
 

--- a/src/rrt/Tree.hpp
+++ b/src/rrt/Tree.hpp
@@ -363,9 +363,9 @@ public:
 
         //  Make sure there's actually a direct path from @source to
         //  @intermediateState.  If not, abort
-        if (!_stateSpace->transitionValid(
-                _forward ? source->state() : intermediateState,
-                _forward ? intermediateState : source->state())) {
+        T from = _forward ? source->state() : intermediateState,
+          to = _forward ? intermediateState : source->state();
+        if (!_stateSpace->transitionValid(from, to)) {
             return nullptr;
         }
 

--- a/src/rrt/Tree.hpp
+++ b/src/rrt/Tree.hpp
@@ -129,12 +129,14 @@ public:
     Tree& operator=(const Tree&) = delete;
     Tree(std::shared_ptr<StateSpace<T>> stateSpace,
          std::function<size_t(T)> hashT, int dimensions,
+         bool forward = true,
          std::function<T(double*)> arrayToT = NULL,
          std::function<void(T, double*)> TToArray = NULL)
         : _kdtree(flann::KDTreeSingleIndexParams()),
           _dimensions(dimensions),
           _nodemap(20, hashT) {
         _stateSpace = stateSpace;
+        _forward = forward;
         _arrayToT = arrayToT;
         _TToArray = TToArray;
 
@@ -363,7 +365,7 @@ public:
 
         //  Make sure there's actually a direct path from @source to
         //  @intermediateState.  If not, abort
-        if (!_stateSpace->transitionValid(source->state(), intermediateState)) {
+        if (!_stateSpace->transitionValid(_forward ? source->state() : intermediateState, _forward ? intermediateState : source->state())) {
             return nullptr;
         }
 
@@ -525,5 +527,6 @@ protected:
     std::function<void(T, double*)> _TToArray;
 
     std::shared_ptr<StateSpace<T>> _stateSpace{};
+    bool _forward;
 };
 }  // namespace RRT


### PR DESCRIPTION
This disallows planning paths into obstacles, which screws up the
smoothing step.

This fixes https://github.com/RoboJackets/robocup-software/issues/1208.