### PR TITLE
Update to Ubuntu 19.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ add_library("RRT" ${lib_SRC})
 add_dependencies(RRT Flann)
 # Fix 'LZ4 not found' issue on some systems
 target_link_libraries(RRT ${FLANN_LIBRARIES})
+target_link_libraries(RRT lz4)
 
 
 # copy headers to install directory


### PR DESCRIPTION
This was throwing tons of `undefined reference to lz4_decompress_safe continue' flann` errors in random places so I had to add this in to link correctly. It seems like this was already a problem in previous versions so this is another bandaid fix.