### PR TITLE
Fix linking for libflann on Ubuntu 19.*+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,38 +1,12 @@
-defaults: &dir
+defaults_dir: &dir
   working_directory: ~/rrt
 
-defaults: &image
+defaults_image: &image
   docker:
     - image: robojackets/rrt:master
 
-defaults: &install_deps
-  run: sudo ./ci/ubuntu-setup.sh && sudo ccache -M 100M
-defaults: &save_src_cache
-  save_cache:
-    key: source-v1-{{ .Branch }}-{{ .Revision }}
-    paths:
-      - ".git"
-
-defaults: &save_compile_cache
-  save_cache:
-    key: ccache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-    paths:
-      - ~/.ccache
-defaults: &load_compile_cache
-  restore_cache:
-    keys:
-      - ccache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-      - ccache-{{ arch }}-{{ .Branch }}
-      - ccache-{{ arch }}
-      - ccache-
-defaults: &save_workspace
-  persist_to_workspace:
-    root: build
-    paths:
-      - ./*
-defaults: &load_workspace
-  attach_workspace:
-    at: build
+defaults_deps: &install_deps
+  run: sudo ./ci/ubuntu-setup.sh
 
 version: 2
 jobs:
@@ -43,10 +17,7 @@ jobs:
       - checkout
       # Ensure latest deps are installed
       - <<: *install_deps
-      - <<: *load_compile_cache
       - run: make
-      - <<: *save_compile_cache
-      - <<: *save_workspace
 
   tests:
     <<: *dir
@@ -55,8 +26,6 @@ jobs:
       - checkout
       # Ensure latest deps are installed
       - <<: *install_deps
-      - <<: *load_workspace
-      - <<: *load_compile_cache
       - run: make tests
 
   style:
@@ -66,8 +35,6 @@ jobs:
       - checkout
       # Ensure latest deps are installed
       - <<: *install_deps
-      - <<: *load_workspace
-      - <<: *load_compile_cache
       - run: git fetch origin && STYLIZE_DIFFBASE=origin/master make checkstyle
       - store_artifacts:
           path: /tmp/clean.patch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,14 @@ add_dependencies(RRT Flann)
 # Fix 'LZ4 not found' issue on some systems
 target_link_libraries(RRT ${FLANN_LIBRARIES})
 
+# Find LZ4 if it exists. On some platforms this is required to make Flann work,
+# while on others it appears to work fine without linking it in (Flann may have
+# previously distributed LZ4 symbols statically, but stopped in later versions?
+find_library(LZ4_LIBRARY NAMES lz4)
+if(LZ4_LIBRARY)
+    target_link_libraries(RRT ${LZ4_LIBRARY})
+endif()
+
 
 # copy headers to install directory
 set(lib_HEADERS
@@ -96,7 +104,6 @@ qt5_add_resources(RESOURCES src/rrt-viewer/main.qrc)
 add_executable("rrt-viewer" ${ui_SRC} ${RESOURCES})
 qt5_use_modules("rrt-viewer" Widgets Qml Quick)
 target_link_libraries("rrt-viewer" RRT)
-
 
 # gtest
 ################################################################################


### PR DESCRIPTION
This links in LZ4 conditionally. It looks like the flann versions packaged in older operating systems didn't play nice, but the CMake scripts we use (`FindFlann.cmake`) don't properly deal with the fact that this was fixed in newer package versions. This should compile it only if necessary.