### PR TITLE
Added virtual destructor to Tree

### DIFF
--- a/src/rrt/Tree.hpp
+++ b/src/rrt/Tree.hpp
@@ -149,6 +149,8 @@ public:
         setGoalMaxDist(0.1);
     }
 
+    virtual ~Tree() = default;
+
     StateSpace<T>& stateSpace() { return *_stateSpace; }
     const StateSpace<T>& stateSpace() const { return *_stateSpace; }
 


### PR DESCRIPTION
`RRT::Tree` has `virtual` functions but is missing a `virtual` destructor. This PR adds that in.